### PR TITLE
Fix property hash initialization

### DIFF
--- a/providers/configuration.rb
+++ b/providers/configuration.rb
@@ -49,7 +49,7 @@ def load_current_resource
   EOS
 
   properties, languages = YAML.load_stream(powershell_out64(script).stdout)
-  @current_resource.properties properties
+  @current_resource.properties.merge! properties
   @current_resource.update_languages languages
 end
 

--- a/providers/notification.rb
+++ b/providers/notification.rb
@@ -41,7 +41,7 @@ def load_current_resource
   }
   EOS
 
-  @current_resource.properties(YAML.load(powershell_out64(script).stdout))
+  @current_resource.properties.merge! YAML.load(powershell_out64(script).stdout)
 end
 
 action :configure do

--- a/providers/subscription.rb
+++ b/providers/subscription.rb
@@ -57,7 +57,7 @@ def load_current_resource
   @category_map = categories || {}
   @classificiation_map = classifications || {}
 
-  @current_resource.properties properties
+  @current_resource.properties.merge! properties
   @current_resource.categories @category_map.values
   @current_resource.classifications @classificiation_map.values
 end

--- a/resources/configuration.rb
+++ b/resources/configuration.rb
@@ -21,6 +21,15 @@ include WsusServer::BaseResource
 
 default_action :configure
 
+def initialize(name, run_context = nil)
+  super(name, run_context)
+
+  # Default computed value for master_server is nil
+  @properties['UpstreamWsusServerName'] = nil
+  @properties['SyncFromMicrosoftUpdate'] = true
+  @properties['IsReplicaServer'] = false
+end
+
 def master_server(arg = nil)
   if arg.nil?
     if @properties['IsReplicaServer'] == true && properties['SyncFromMicrosoftUpdate'] == false


### PR DESCRIPTION
Fix #4
Define default computed value `master_server` to `nil` by setting:
 * `UpstreamWsusServerName` to `nil`
 * `SyncFromMicrosoftUpdate` to `true`
 * `IsReplicaServer` to `false`

Merge properly resource properties when loading current resource.