### PR TITLE
setup option is SQL_INSTANCE_NAME instead of SQLINSTANCE_NAME

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,8 +22,18 @@ return unless platform?('windows')
 
 setup_conf = node['wsus_server']['setup']
 
+require 'chef/win32/version'
+windows_version = Chef::ReservedNames::Win32::Version.new
+
 setup_options = ''
-setup_options << " SQL_INSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""        if setup_conf['sqlinstance_name']
+
+if setup_conf['sqlinstance_name']
+  if windows_version.windows_server_2012_r2?
+    setup_options << " SQL_INSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""
+  else
+    setup_options << " SQLINSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""
+  end
+end
 
 if setup_conf['content_dir']
   setup_options << " CONTENT_LOCAL=1 CONTENT_DIR=\"#{setup_conf['content_dir']}\""
@@ -33,7 +43,6 @@ if setup_conf['content_dir']
   end
 end
 
-require 'chef/win32/version'
 if node['platform_version'].to_f >= 6.2
 
   windows_feature 'UpdateServices' do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,7 +23,7 @@ return unless platform?('windows')
 setup_conf = node['wsus_server']['setup']
 
 setup_options = ''
-setup_options << " SQLINSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""        if setup_conf['sqlinstance_name']
+setup_options << " SQL_INSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""        if setup_conf['sqlinstance_name']
 
 if setup_conf['content_dir']
   setup_options << " CONTENT_LOCAL=1 CONTENT_DIR=\"#{setup_conf['content_dir']}\""


### PR DESCRIPTION
When installing wsus on Windows Server 2012 R2 we are receiving the following error;

the WID role service is not installed, the instance name must be specified on the commandline

After investigation it seems like a wrong setup_option is used;

recipes/install.rb:setup_options << " SQLINSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""   

instead of ;

recipes/install.rb:setup_options << " SQL_INSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\"" 

Could you please have a look and merge this pull request. Maybe it's cleaner for consistency to use sql_instance_name in all files;

spec/recipes/install_spec.rb:      chef_run = windows2012_chef_run(wsus_server: { setup: { sqlinstance_name: nil } })
spec/recipes/install_spec.rb:      chef_run = windows2012_chef_run(wsus_server: { setup: { sqlinstance_name: 'instance' } })
attributes/install.rb:default['wsus_server']['setup']['sqlinstance_name']             = nil
attributes/install.rb:  # Frontend server shares the configuration of the main server, using the value of above attribute sqlinstance_name.
recipes/install.rb:setup_options << " SQLINSTANCE_NAME=\"#{setup_conf['sqlinstance_name']}\""        if setup_conf['sqlinstance_name']
recipes/install.rb:    action         setup_conf['sqlinstance_name'] ? :install : :remove
recipes/install.rb:    action         setup_conf['sqlinstance_name'] ? :remove : :install
README.md:sqlinstance_name| Local or remote SQL instance for WSUS configuration| String | `nil`


With kind regards,

Jos Munnik
     