### PR TITLE
Fix bug

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -45,21 +45,25 @@ if node['platform_version'].to_f >= 6.2
   windows_feature 'UpdateServices' do
     action         :install
     all            true
+    provider       :windows_feature_powershell   
   end
 
   windows_feature 'UpdateServices-UI' do
     action         :install
     all            true
+    provider       :windows_feature_powershell   
   end
 
-  windows_feature 'UpdateServices-Database' do
-    action         setup_conf['sqlinstance_name'] ? :install : :remove
-    all            true
-  end
-
-  windows_feature 'UpdateServices-WidDatabase' do
+  windows_feature 'UpdateServices-WidDB' do
     action         setup_conf['sqlinstance_name'] ? :remove : :install
     all            true
+    provider       :windows_feature_powershell
+  end
+  
+  windows_feature 'UpdateServices-DB' do
+    action         setup_conf['sqlinstance_name'] ? :install : :remove
+    all            true
+    provider       :windows_feature_powershell
   end
 
   guard_file = ::File.join(Chef::Config['file_cache_path'], 'wsus_postinstall')
@@ -106,6 +110,7 @@ else
   features.each do |feature_name|
     windows_feature feature_name do
       action       :install
+      provider     :windows_feature_powershell
     end
   end
 


### PR DESCRIPTION
Bug Fix

Default provider for windows_feature - DISM. After installing features with DISM you can see in Server Manger -> Server Roles  -> - no sub roles installed (Related to WSUS - WID, WSUS services, database) (They are really installed and you can check it by DISM commands and use them as well but they not visible from powershell Get-WindowsFeature and Server Manager). It can confuse.

To avoid that problem we should use provider windows_feature_powershell from windows cookbook. That way all installed roles and subroles visible from any tool (DISM, PowerShell, ServerManager)

Changes:
1) Specified provider for windows_feature "windows_feature_powershell" in *install.rb*
2) New version in *metadata.rb* (1.0.4)
