### PR TITLE
Add configure_timeout attribute for the wsus_server_subscription :configure action 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ properties               | Hash to configure all [ISubscription][subscription_me
 synchronization_per_day  | Number of server-to-server synchronizations a day | FixNum
 synchronization_time     | Time of day to automatically synchronize updates  | String
 synchronize_categories   | Whether to only synchronize categories not updates| TrueClass, FalseClass
+configure_timeout        | Timeout in seconds for subscription configuration | FixNum
 
 Recipes
 -------
@@ -137,6 +138,7 @@ properties                | Hash to configure all [ISubscription][subscription_m
 synchronization_per_day   | Number of server-to-server synchronizations a day          | FixNum                | `12`
 synchronization_time      | Time of day when WSUS synchronize updates and categories   | String                | `00:00:00`
 synchronize_categories    | Synchronizes categories before configuring other settings  | TrueClass, FalseClass | `true`
+configure_timeout         | Timeout in seconds for subscription configuration          | FixNum                | `900`
 
 
 ## wsus-server::default

--- a/attributes/configure.rb
+++ b/attributes/configure.rb
@@ -59,6 +59,8 @@ default['wsus_server']['subscription']['synchronization_per_day']       = '12'
 default['wsus_server']['subscription']['synchronization_time']          = '00:00:00'
 # Determines whether WSUS should synchronize categories before configuring above attributes.
 default['wsus_server']['subscription']['synchronize_categories']        = true
+# Defines the timeout in seconds for the subscription configuration (including category synchronization if synchronize_categories is true)
+default['wsus_server']['subscription']['configure_timeout']             = 900
 
 # -----
 # Following notification attributes are based on the IEmailNotificationConfiguration interface

--- a/libraries/base_provider.rb
+++ b/libraries/base_provider.rb
@@ -49,7 +49,7 @@ module WsusServer
       @endpoint ||= @new_resource.endpoint ? WsusServer::BaseProvider.uri_to_wsus_endpoint_params(@new_resource.endpoint) : ''
     end
 
-    def powershell_out64(cmd)
+    def powershell_out64(cmd, timeout=300)
       flags = [
         # Hides the copyright banner at startup.
         '-NoLogo',
@@ -70,7 +70,7 @@ module WsusServer
       # Use the sysnative folder to target the right powershell binary
       # => https://msdn.microsoft.com/en-us/library/windows/desktop/aa384187.aspx
       interpreter = '%windir%/SysNative/WindowsPowershell/v1.0/PowerShell.exe'
-      cmd = shell_out "#{interpreter} #{flags.join(' ')} -EncodedCommand #{encoded_command}", timeout: 300
+      cmd = shell_out "#{interpreter} #{flags.join(' ')} -EncodedCommand #{encoded_command}", timeout: timeout
       cmd.error!
       fail 'Invalid syntax in PowershellScript' if cmd.stderr && cmd.stderr.include?('ParserError')
       cmd

--- a/providers/subscription.rb
+++ b/providers/subscription.rb
@@ -130,7 +130,7 @@ action :configure do
       end
       script << '      $conf.Save()'
 
-      powershell_out64 script
+      powershell_out64(script, @new_resource.configure_timeout)
     end
     new_resource.updated_by_last_action true
   end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -41,6 +41,7 @@ unless server_conf['master_server'] || server_conf['properties']['IsReplicaServe
     synchronization_per_day                        subscription_conf['synchronization_per_day']
     synchronization_time                           subscription_conf['synchronization_time']
     synchronize_categories                         subscription_conf['synchronize_categories']
+    configure_timeout                              subscription_conf['configure_timeout']
   end
 
   # Updates notification settings

--- a/resources/subscription.rb
+++ b/resources/subscription.rb
@@ -58,5 +58,5 @@ def synchronize_categories(arg = nil)
 end
 
 def configure_timeout(arg = nil)
-  set_or_return(:configure_timeout, arg, kind_of: FixNum)
+  set_or_return(:configure_timeout, arg, kind_of: Fixnum)
 end

--- a/resources/subscription.rb
+++ b/resources/subscription.rb
@@ -56,3 +56,7 @@ end
 def synchronize_categories(arg = nil)
   set_or_return(:synchronize_categories, arg, kind_of: [TrueClass, FalseClass])
 end
+
+def configure_timeout(arg = nil)
+  set_or_return(:configure_timeout, arg, kind_of: FixNum)
+end


### PR DESCRIPTION
Somewhat crude solution for #13 to allow for the timeout for the `:configure` action of the `wsus_server_subscription` provider to be set through an attribute.
I was seeing the same problem identified in the issue whereby the category synchronisation was not completing within the 300 seconds hardcoded by the `powershell_out64` method.
This solution sets the default timeout for `powershellout_64` as 300 seconds, but allows for that to be overridden. 
In the case of `wsus_server_subscription` I pull that timeout from an attribute (which itself is defaulted to 900 seconds).
