### PR TITLE
fix in order to work with chef-client 12.11.18 (x64) and use helper …

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'b.courtois@criteo.com'
 license          'Apache 2.0'
 description      'Installs wsus server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.4'
+version          '1.0.5'
 supports         'windows'
 depends          'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'b.courtois@criteo.com'
 license          'Apache 2.0'
 description      'Installs wsus server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.5'
+version          '1.0.4'
 supports         'windows'
 depends          'windows'


### PR DESCRIPTION
Hi,

Can you have a look at the fix as it's solving the issue below and compatible with older clients.

Regards,
Jos

Failure with chef 12.11.18

Generated at 2016-07-11 23:09:22 +0200
Mixlib::ShellOut::ShellCommandFailed: wsus_server_configuration[Wsus server configuration] (wsus-server::configure line 27) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of %windir%/SysNative/WindowsPowershell/v1.0/PowerShell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -InputFormat None -EncodedCommand BLA ----
STDOUT: 
STDERR: The system cannot find the path specified.
---- End output of %windir%/SysNative/WindowsPowershell/v1.0/PowerShell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -InputFormat None -EncodedCommand BLA ----
Ran %windir%/SysNative/WindowsPowershell/v1.0/PowerShell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy RemoteSigned -InputFormat None -EncodedCommand BLA returned 1
c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6-universal-mingw32/lib/mixlib/shellout.rb:289:in `invalid!'
c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.2.6-universal-mingw32/lib/mixlib/shellout.rb:276:in `error!'
C:/chef/cache/cookbooks/wsus-server/libraries/base_provider.rb:74:in `powershell_out64'
C:/chef/cache/cookbooks/wsus-server/providers/configuration.rb:51:in `load_current_resource'
c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/provider.rb:128:in `run_action'
c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/resource.rb:591:in `run_action'

With applied change:

Recipe: wsus-server::synchronize
  * powershell_script[WSUS Update Synchronization] action run
    - execute "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -File "C:/Users/BLA~1/AppData/Local/Temp/2/chef-script20160711-3200-12jpq7r.ps1"
Recipe: sbp_wsus-server_wrapper::default
  * powershell_script[Creating WSUS Groups] action run
    - execute "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -File "C:/Users/BLA~1/AppData/Local/Temp/2/chef-script20160711-3200-g2njdl.ps1"
Recipe: sbp_app_inventory::default
