### PR TITLE
Fix Issue #26 and add new windows powershell routine

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'b.courtois@criteo.com'
 license          'Apache 2.0'
 description      'Installs wsus server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.0'
+version          '2.1.1'
 supports         'windows'
 depends          'windows'
 


### PR DESCRIPTION
Fixes issue #26 by configuring an array for the needed powershell features based on database choice , rather than installing all and removing unneeded features afterwards (which causes an error in new windows cookbooks, with new powershell routine.)

Also using new powershell routine from windows cookbook version >= '3'.
Where all features are installed at once by the windows powershell feature, rather than looping through the array one by one (still used by older windows cookbooks, hence backward compatible)