### PR TITLE
Do not install all UpdateServices subfeatures

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -48,7 +48,6 @@ if node['platform_version'].to_f >= 6.2
   ].each do |feature_name|
     windows_feature feature_name do
       action         :install
-      all            true
       install_method :windows_feature_powershell if respond_to? :install_method
       provider       :windows_feature_powershell unless respond_to? :install_method
     end


### PR DESCRIPTION
With windows cookbook >= 3, the powershell provider of windows_feature
is now implementing the `all` property to install child features.
This behavior is different than the on from the DISM provider.
Before the version 3 of the windows cookbook, the `all` property was
ignored.

c3935b3aa6793a7633739cdecbc0f4e8e34efff8 started to use the powershell
provider, but forgot to remove the `all` property.
Removing it should do the trick.

See chef-cookbooks/windows#493
Fix #26