### PR TITLE
Quote strings when loading the configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem 'chefspec',   '>= 4.2'
   gem 'fauxhai',    '>= 2.2'
   gem 'foodcritic', '>= 4.0'
+  gem 'gherkin',    '~> 5.1'
 
   platforms :mri_19 do
     gem 'ohai', '~> 7.4.0'

--- a/providers/configuration.rb
+++ b/providers/configuration.rb
@@ -33,7 +33,7 @@ def load_current_resource
       [Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
 
       # Defines single-level "YAML" formatters to avoid DateTime and TimeSpan conversion issue in ruby
-      $valueFormatter = { param($_); if ($_ -is [DateTime] -or $_ -is [TimeSpan]) { "'$($_)'" } else { $_ } }
+      $valueFormatter = { param($_); if ($_ -is [DateTime] -or $_ -is [TimeSpan] -or $_ -is [String]) { $_ = $_ -replace "'", "''"; "'$($_)'" } else { $_ } }
       $objectFormatter = { param($_); $_.psobject.Properties | foreach { "$($_.name): $(&$valueFormatter $_.value)" } }
 
       $wsus = [Microsoft.UpdateServices.Administration.AdminProxy]::GetUpdateServer(#{endpoint_params})


### PR DESCRIPTION
If one of the configuration parameters contains an invalid yaml
character, it breaks the parsing. This change quotes strings and
ensures if there is a quote in a string, it will be doubled so it
is escaped in yaml.