### PR TITLE
Use ProxyPassword from the resource definition

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -27,6 +27,7 @@ server_conf = node['wsus_server']['configuration']
 wsus_server_configuration 'Wsus server configuration' do
   master_server                                    server_conf['master_server']
   update_languages                                 server_conf['update_languages']
+  proxy_password                                   server_conf['proxy_password']
   properties                                       server_conf['properties']
 end
 


### PR DESCRIPTION
The proxy password is defined at the resource level, and
we do not redifine it as a property before trying to update it.

So do like for languages, check if it changed and set it separately.

Also fix the configure recipe as the proxy_password was never given,
so we would have never updated it.