### PR TITLE
Translate TrueClass/FalseClass into correct powershell value

### DIFF
--- a/libraries/base_provider.rb
+++ b/libraries/base_provider.rb
@@ -82,8 +82,8 @@ module WsusServer
 
     def powershell_value(val)
       case val
-      when FalseClass
-        'false'
+      when TrueClass, FalseClass
+        "$#{val}"
       when Array
         "@(#{val.map { |v| powershell_value(v) }.join(',')})"
       when Hash


### PR DESCRIPTION
Equivalents of TrueClass & FalseClass in powershell are `$true` & `$false`.